### PR TITLE
Fix infinite loop check to respect allowed_bots configuration

### DIFF
--- a/src/felix.ts
+++ b/src/felix.ts
@@ -163,8 +163,8 @@ export class FixitFelix {
         return false
       }
 
-      // Check if the last commit was made by Felix or other bots
-      const felixIndicators = ['fix-it-felix', 'felix', 'github-actions', 'bot']
+      // Check if the last commit was made by Felix or other specific bots
+      const felixIndicators = ['fix-it-felix', 'felix', 'github-actions[bot]']
       const isLastCommitByFelix = felixIndicators.some(indicator =>
         lastAuthor.toLowerCase().includes(indicator)
       )

--- a/tests/felix.test.ts
+++ b/tests/felix.test.ts
@@ -231,7 +231,8 @@ describe('FixitFelix', () => {
       { input: 'renovate', author: 'renovate[bot]', shouldProceed: true },
       { input: 'dependabot,renovate', author: 'renovate[bot]', shouldProceed: true },
       { input: 'dependabot', author: 'other-bot[bot]', shouldProceed: false },
-      { input: '', author: 'dependabot[bot]', shouldProceed: false }
+      { input: '', author: 'dependabot[bot]', shouldProceed: false },
+      { input: 'devin-ai-integration', author: 'devin-ai-integration[bot]', shouldProceed: true }
     ]
 
     testCases.forEach(({ input, author, shouldProceed }) => {


### PR DESCRIPTION
- Remove overly broad 'bot' indicator that was catching allowed bots
- Change to more specific 'github-actions[bot]' to prevent false positives
- Add test case for devin-ai-integration[bot] scenario
- Fixes issue where allowed bots were incorrectly flagged as infinite loop risk